### PR TITLE
Modularize quality checks

### DIFF
--- a/lib/quality/cane.rb
+++ b/lib/quality/cane.rb
@@ -1,0 +1,25 @@
+module Quality
+  private
+
+  module Cane
+    def write_out_dot_cane
+      @configuration_writer.open('.cane', 'w') do |file|
+        file.write('-f **/*.rb')
+      end
+    end
+
+    def quality_cane
+      write_out_dot_cane unless @configuration_writer.exist?('.cane')
+
+      ratchet_quality_cmd('cane',
+                          gives_error_code_on_violations: true,
+                          emacs_format: true) do |line|
+        if line =~ /\(([0-9]*)\):$/
+          Regexp.last_match[1].to_i
+        else
+          0
+        end
+      end
+    end
+  end
+end

--- a/lib/quality/flay.rb
+++ b/lib/quality/flay.rb
@@ -1,0 +1,17 @@
+module Quality
+  module Flay
+    def quality_flay
+      private
+
+      ratchet_quality_cmd('flay',
+                          args: "-m 75 -t 99999 #{ruby_files}",
+                          emacs_format: true) do |line|
+        if line =~ /^[0-9]*\).* \(mass = ([0-9]*)\)$/
+          Regexp.last_match[1].to_i
+        else
+          0
+        end
+      end
+    end
+  end
+end

--- a/lib/quality/flog.rb
+++ b/lib/quality/flog.rb
@@ -1,0 +1,30 @@
+module Quality
+  module Flog
+    private
+
+    def quality_flog
+      args = "--all --continue --methods-only #{ruby_files}"
+      ratchet_quality_cmd('flog', args: args, emacs_format: true) do |line|
+        self.class.count_violations_in_flog_output(line)
+      end
+    end
+
+    def self.included(base)
+      base.extend ClassMethods
+    end
+
+    module ClassMethods
+      def count_violations_in_flog_output(line, threshold = 50)
+        return 0 if line =~ /^ *([0-9.]*): flog total$/
+
+        return 0 unless line =~ /^ *([0-9.]*): (.*) .*.rb:[0-9]*$/
+
+        score = Regexp.last_match[1].to_i
+
+        return 1 if score > threshold
+
+        0
+      end
+    end
+  end
+end

--- a/lib/quality/reek.rb
+++ b/lib/quality/reek.rb
@@ -1,0 +1,29 @@
+module Quality
+  module Reek
+    private
+
+    def quality_reek
+      args = "--single-line #{ruby_files}"
+      ratchet_quality_cmd('reek',
+                          args: args,
+                          emacs_format: true,
+                          gives_error_code_on_violations: true) do |line|
+        self.class.count_reek_violations(line)
+      end
+    end
+
+    def self.included(base)
+      base.extend ClassMethods
+    end
+
+    module ClassMethods
+      def count_reek_violations(line)
+        if line =~ /^  .* (.*)$/
+          1
+        else
+          0
+        end
+      end
+    end
+  end
+end

--- a/lib/quality/rubocop.rb
+++ b/lib/quality/rubocop.rb
@@ -1,0 +1,27 @@
+module Quality
+  module Rubocop
+    private
+
+    def quality_rubocop
+      ratchet_quality_cmd('rubocop',
+                          gives_error_code_on_violations: true,
+                          args: "--format emacs #{ruby_files}") do |line|
+        self.class.count_rubocop_violations(line)
+      end
+    end
+
+    def self.included(base)
+      base.extend ClassMethods
+    end
+
+    module ClassMethods
+      def count_rubocop_violations(line)
+        if line =~ /^.* file[s|] inspected, (.*) offence[s|] detected$/
+          0
+        else
+          1
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This helps to reduce the length of `lib/quality/rake/task.rb`, which Rubocop currently gives a warning for.

There are currently some Cane/Rubocop warnings due to missing documentation for the new modules but I wanted to check first that you're in general agreement with this proposed change.
