### PR TITLE
Reduce dependency injection

### DIFF
--- a/lib/quality/quality_checker.rb
+++ b/lib/quality/quality_checker.rb
@@ -8,7 +8,6 @@ module Quality
   class QualityChecker
     def initialize(cmd, command_options, output_dir, dependencies = {})
       @popener = dependencies[:popener] || IO
-      @count_file = dependencies[:count_file] || File
       @count_io = dependencies[:count_io] || IO
       @command_output_processor_class =
         dependencies[:command_output_processor_class] ||
@@ -51,7 +50,7 @@ module Quality
     end
 
     def existing_violations
-      if @count_file.exist?(@filename)
+      if File.exist?(@filename)
         @count_io.read(@filename).to_i
       else
         9_999_999_999
@@ -101,7 +100,7 @@ module Quality
     end
 
     def write_violations(new_violations)
-      @count_file.open(@filename, 'w') do |file|
+      File.open(@filename, 'w') do |file|
         file.write(new_violations.to_s)
       end
     end

--- a/test/unit/test_quality_checker.rb
+++ b/test/unit/test_quality_checker.rb
@@ -77,7 +77,7 @@ class TestQualityChecker < Test::Unit::TestCase
 
   def expect_write_new_violations(num_violations, hwm_filename)
     file = mock('file')
-    @mocks[:count_file].expects(:open).with(hwm_filename, 'w').yields(file)
+    File.expects(:open).with(hwm_filename, 'w').yields(file)
     file.expects(:write).with(num_violations.to_s)
   end
 
@@ -92,13 +92,12 @@ class TestQualityChecker < Test::Unit::TestCase
   end
 
   def expect_file_exist?(filename, exists)
-    @mocks[:count_file].expects(:exist?).with(filename).returns(exists)
+    File.expects(:exist?).with(filename).returns(exists)
   end
 
   def test_mocks
     {
       popener: mock('popener'),
-      count_file: mock('count_file'),
       count_io: mock('count_io'),
       command_output_processor_class: mock('command_output_processor_class'),
     }


### PR DESCRIPTION
I noticed that one of the Reek warnings was concerning a high number (13) of instance variables in `QualityChecker`.

Looking into this, I see that dependency injection is being used in order to stub and set expectations during testing.

With Ruby's runtime flexibility, we can actually stub or set expectations on directly on the real classes. I've illustrated this for just `count_file` in this PR but there are several other variables this could apply to. This would help to improve the QualityChecker class by reducing the number of instance variables, simplifying the initializer, and reducing the amount of indirection.

I realise that there are other reasons for using Dependency Injection than just for testing. But since these File is a core Ruby class, it seems unlikely this would ever need to change.

What do you think?
