### PR TITLE
Use long arg names

### DIFF
--- a/lib/quality/tools/flay.rb
+++ b/lib/quality/tools/flay.rb
@@ -6,7 +6,7 @@ module Quality
 
       def quality_flay
         ratchet_quality_cmd('flay',
-                            args: "-m 75 -t 99999 #{ruby_files}",
+                            args: "--mass 75 --timeout 99999 #{ruby_files}",
                             emacs_format: true) do |line|
           if line =~ /^[0-9]*\).* \(mass = ([0-9]*)\)$/
             Regexp.last_match[1].to_i

--- a/test/unit/tools/flay.rb
+++ b/test/unit/tools/flay.rb
@@ -17,7 +17,7 @@ module Test
         private
 
         def flay_args
-          '-m 75 -t 99999 ' \
+          '--mass 75 --timeout 99999 ' \
             'fake1.rb fake2.rb lib/libfake1.rb ' \
             'test/testfake1.rb features/featuresfake1.rb'
         end


### PR DESCRIPTION
Makes the code more self-documenting
