### PR TITLE
Add newline at end of written files

### DIFF
--- a/lib/quality/quality_checker.rb
+++ b/lib/quality/quality_checker.rb
@@ -102,7 +102,7 @@ module Quality
 
     def write_violations(new_violations)
       @count_file.open(@filename, 'w') do |file|
-        file.write(new_violations.to_s)
+        file.write(new_violations.to_s + "\n")
       end
     end
   end

--- a/lib/quality/rake/task.rb
+++ b/lib/quality/rake/task.rb
@@ -168,7 +168,7 @@ module Quality
 
       def write_violations(filename, new_violations)
         @count_file.open(filename, 'w') do |file|
-          file.write(new_violations.to_s)
+          file.write(new_violations.to_s + "\n")
         end
       end
 

--- a/test/unit/test_quality_checker.rb
+++ b/test/unit/test_quality_checker.rb
@@ -78,7 +78,7 @@ class TestQualityChecker < Test::Unit::TestCase
   def expect_write_new_violations(num_violations, hwm_filename)
     file = mock('file')
     @mocks[:count_file].expects(:open).with(hwm_filename, 'w').yields(file)
-    file.expects(:write).with(num_violations.to_s)
+    file.expects(:write).with(num_violations.to_s + "\n")
   end
 
   def expect_existing_violations_read(existing_violations, hwm_filename)

--- a/test/unit/test_task.rb
+++ b/test/unit/test_task.rb
@@ -87,7 +87,7 @@ class TestTask < Test::Unit::TestCase
   def expect_write_to_high_water_mark(filename, new_high_water_mark)
     file = mock('file')
     @mocks[:count_file].expects(:open).with(filename, 'w').yields(file)
-    file.expects(:write).with(new_high_water_mark.to_s)
+    file.expects(:write).with(new_high_water_mark.to_s + "\n")
   end
 
   def expect_installed(tool_name)


### PR DESCRIPTION
Without this, GitHub will show a "No newline at end of file" warning for the high water mark files.
