### PR TITLE
Don't output `Suppressing use of ...`

### DIFF
--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 97.24
+    "covered_percent": 97.45
   }
 }

--- a/lib/quality/rake/task.rb
+++ b/lib/quality/rake/task.rb
@@ -141,12 +141,9 @@ module Quality
 
       def run_quality_with_tool(tool)
         installed = @gem_spec.find_all_by_name(tool).any?
-        suppressed = @skip_tools.include? tool
 
         if !installed
           puts "#{tool} not installed"
-        elsif suppressed
-          puts "Suppressing use of #{tool}"
         else
           method("quality_#{tool}".to_sym).call
         end


### PR DESCRIPTION
This feels like unnecessary noise in the output. The Rakefile configuration already makes it clear which tools are to be skipped.
