### PR TITLE
Include `app` in default directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ Quality::Rake::Task.new { |t|
 
   # Array of directory names which contain ruby files to analyze.
   #
-  # Defaults to %w{lib test spec feature}, which translates to *.rb in the base directory, as well as lib, test, spec, and feature.
-  t.ruby_dirs = %w{lib test spec feature}
+  # Defaults to %w{app lib test spec feature}, which translates to *.rb in the base directory, as well as those directories.
+  t.ruby_dirs = %w{app lib test spec feature}
 
   # Relative path to output directory where *_high_water_mark
   # files will be read/written

--- a/lib/quality/rake/task.rb
+++ b/lib/quality/rake/task.rb
@@ -50,8 +50,8 @@ module Quality
 
       # Array of directory names which contain ruby files to analyze.
       #
-      # Defaults to %w(lib test spec feature), which translates to *.rb in
-      # the base directory, as well as lib, test, and feature.
+      # Defaults to %w(app lib test spec feature), which translates to *.rb in
+      # the base directory, as well as those directories.
       attr_writer :ruby_dirs
 
       # Relative path to output directory where *_high_water_mark
@@ -184,7 +184,7 @@ module Quality
       end
 
       def ruby_dirs
-        @ruby_dirs ||= %w(lib test spec feature)
+        @ruby_dirs ||= %w(app lib test spec feature)
       end
 
       def ruby_files_glob

--- a/test/unit/test_task.rb
+++ b/test/unit/test_task.rb
@@ -99,7 +99,7 @@ class TestTask < Test::Unit::TestCase
 
   def expect_find_ruby_files
     expect_glob.with('*.rb').returns(['fake1.rb', 'fake2.rb'])
-    expect_glob.with('{lib,test,spec,feature}/**/*.rb')
+    expect_glob.with('{app,lib,test,spec,feature}/**/*.rb')
       .returns(['lib/libfake1.rb',
                 'test/testfake1.rb',
                 'features/featuresfake1.rb'])


### PR DESCRIPTION
Since Rails is so prevalent I believe it makes sense to include this.
