### PR TITLE
Use minitest directly

### DIFF
--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 97.24
+    "covered_percent": 97.45
   }
 }

--- a/test/unit/test_command_output_processor.rb
+++ b/test/unit/test_command_output_processor.rb
@@ -1,7 +1,7 @@
 require_relative 'test_helper'
 
 # Test the CommandOutputProcessor class
-class TestCommandOutputProcessor < Test::Unit::TestCase
+class TestCommandOutputProcessor < MiniTest::Unit::TestCase
   def test_process_vanilla
     @processor = get_test_object
     @processor.file = vanilla_file

--- a/test/unit/test_helper.rb
+++ b/test/unit/test_helper.rb
@@ -4,5 +4,5 @@ SimpleCov.start do
 end
 SimpleCov.refuse_coverage_drop
 require_relative '../../lib/quality/rake/task'
-require 'test/unit'
+require 'minitest/autorun'
 require 'mocha/setup'

--- a/test/unit/test_quality_checker.rb
+++ b/test/unit/test_quality_checker.rb
@@ -1,7 +1,7 @@
 require_relative 'test_helper'
 
 # Unit test the QualityChecker class
-class TestQualityChecker < Test::Unit::TestCase
+class TestQualityChecker < MiniTest::Unit::TestCase
   def quality_checker_ratchet
     command_options = {}
     num_violations = 523

--- a/test/unit/test_task.rb
+++ b/test/unit/test_task.rb
@@ -5,7 +5,7 @@ require_relative 'tools/reek'
 require_relative 'tools/rubocop'
 
 # Unit test the Task class
-class TestTask < Test::Unit::TestCase
+class TestTask < MiniTest::Unit::TestCase
   include ::Test::Quality::Tools::Cane
   include ::Test::Quality::Tools::Flay
   include ::Test::Quality::Tools::Flog


### PR DESCRIPTION
Since Ruby 1.9, `test/unit` has just been a wrapper around minitest for backwards compatability:

http://www.rubyinside.com/a-minitestspec-tutorial-elegant-spec-style-testing-that-comes-with-ruby-5354.html

The driver for this change is that I want to add support the Ruby Best Practices gem which has the gem version of minitest as a dependency. Mixing `test/unit` and `minitest` together causes problems.
