### PR TITLE
Replace deprecated call with it's alias

### DIFF
--- a/lib/quality/rake/task.rb
+++ b/lib/quality/rake/task.rb
@@ -80,7 +80,7 @@ module Quality
 
       def define
         desc 'Verify quality has increased or stayed ' \
-             'the same' unless ::Rake.application.last_comment
+             'the same' unless ::Rake.application.last_description
         @dsl.define_task(quality_name) { @runner.run_quality }
         @dsl.define_task(ratchet_name) { @runner.run_ratchet }
         @runner.tools.each do |tool|


### PR DESCRIPTION
Some discussion regarding the change:
https://github.com/ruby/rake/issues/114#issuecomment-194223569

Additional:
https://github.com/ruby/rake/issues/116#issuecomment-195164635
