### PR TITLE
update default list of punchlist options in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ Quality::Rake::Task.new do |t|
   # Pipe-separated regexp string describing what to look for in
   # files as 'todo'-like 'punchlist' comments.
   #
-  # Defaults to 'XXX|TODO'
-  t.punchlist_regexp = 'XXX|TODO'
+  # Defaults to 'XXX|TODO|FIXME|OPTIMIZE|HACK|REVIEW|LATER|FIXIT'
+  t.punchlist_regexp = 'XXX|TODO|FIXME|OPTIMIZE|HACK|REVIEW|LATER|FIXIT'
 
   # Exclude the specified list of files--defaults to ['db/schema.rb']
   t.exclude_files = ['lib/whatever/imported_file.rb',


### PR DESCRIPTION
@vinceatbluelabs bumped the readme here while I was wrenching around on something else -- it appears that the listed defaults are overtaken by events in the punchlist gem itself. This just bumps the readme to reflect what's currently in the punchlist master. 