### PR TITLE
Correctly detect exclude glob in punchlist

### DIFF
--- a/lib/quality/tools/punchlist.rb
+++ b/lib/quality/tools/punchlist.rb
@@ -9,7 +9,7 @@ module Quality
       def punchlist_args
         glob = "--glob '#{source_and_doc_files_glob}'"
         regexp = " --regexp '#{punchlist_regexp}'" if punchlist_regexp
-        unless exclude_files.nil? || exclude_files.empty?
+        unless source_files_exclude_glob == '{}'
           exclude = " --exclude-glob '#{source_files_exclude_glob}'"
         end
 


### PR DESCRIPTION
This matches behavior in [bigfiles](https://github.com/apiology/quality/blob/master/lib/quality/tools/bigfiles.rb) and seems like The Right Thing.