### PR TITLE
Added note to check the environment in the Rakefile (documentation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,16 @@ require 'quality/rake/task'
 Quality::Rake::Task.new
 ```
 
-Make sure you're including `Quality::Rake::Task` only in the
-same environment you've installed the `quality` gem. For example,
-if you're using Rails you may want to check `Rails.env.development?`
-before the require, since Rails uses it's current environment
-as a group for the `Bundler`.
+If you're using Rails, you must check your environment in your
+Rakefile.
+
+```ruby
+if Rails.env.development?
+  require 'quality/rake/task'
+
+  Quality::Rake::Task.new
+end
+```
 
 Then run:
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ require 'quality/rake/task'
 Quality::Rake::Task.new
 ```
 
+Make sure you're including `Quality::Rake::Task` only in the
+same environment you've installed the `quality` gem. For example,
+if you're using Rails you may want to check `Rails.env.development?`
+before the require, since Rails uses it's current environment
+as a group for the `Bundler`.
+
 Then run:
 
 ```bash


### PR DESCRIPTION
In the documentation, it's recommended to include `gem 'quality'` inside a `group :development`, so it's important to suggest the environment verification in the Rakefile as well.

Linked with issue #81.