### PR TITLE
added --force-exclusion command line rubocop argument to correctly process Exclude: parameter in .rubocop.yml

### DIFF
--- a/lib/quality/tools/rubocop.rb
+++ b/lib/quality/tools/rubocop.rb
@@ -11,7 +11,7 @@ module Quality
       private
 
       def rubocop_args
-        "--require rubocop-rspec --format emacs #{ruby_files.join(' ')}"
+        "--force-exclusion --require rubocop-rspec --format emacs #{ruby_files.join(' ')}"
       end
 
       def quality_rubocop


### PR DESCRIPTION
Hi, I discovered there is an issue with `Exclude:` rubocop config parameter being ignored when running rubocop via quality's rake task. This PR solves it. For more details pls see:

https://github.com/bbatsov/rubocop/issues/893
https://github.com/bbatsov/rubocop/issues/2492
https://github.com/bbatsov/rubocop/issues/3979