### PR TITLE
added --force-exclusion command line rubocop argument  to correctly process Exclude: parameter in .rubocop.yml

### DIFF
--- a/lib/quality/tools/rubocop.rb
+++ b/lib/quality/tools/rubocop.rb
@@ -11,7 +11,12 @@ module Quality
       private
 
       def rubocop_args
-        "--require rubocop-rspec --format emacs #{ruby_files.join(' ')}"
+        [
+          '--force-exclusion',
+          '--require rubocop-rspec',
+          '--format emacs',
+          *ruby_files,
+        ].join(' ')
       end
 
       def quality_rubocop

--- a/test/unit/tools/rubocop.rb
+++ b/test/unit/tools/rubocop.rb
@@ -20,8 +20,19 @@ module Test
         private
 
         def rubocop_args
-          '--require rubocop-rspec --format emacs fake1.rb fake2.rb ' \
-          'features/featuresfake1.rb lib/libfake1.rb test/testfake1.rb'
+          [
+            '--force-exclusion',
+            '--require rubocop-rspec',
+            '--format emacs',
+            *ruby_files,
+          ].join(' ')
+        end
+
+        def ruby_files
+          %w[
+            fake1.rb fake2.rb
+            features/featuresfake1.rb lib/libfake1.rb test/testfake1.rb
+          ]
         end
       end
     end


### PR DESCRIPTION
Hi, I discovered there is an issue with `Exclude:` rubocop config parameter being ignored when running rubocop via quality's rake task. This PR solves it.

However I'm not sure how to test this case since `.rubocop.yml` should be involved in configuring rubocop behavior. So for now I only made `rubocop_args` in tests be similar to the actual code to make sure nothing gets broken.

For more details pls see:

https://github.com/bbatsov/rubocop/issues/893
https://github.com/bbatsov/rubocop/issues/2492
https://github.com/bbatsov/rubocop/issues/3979