### PR TITLE
Don't show "not installed" if a tool if suppressed

### DIFF
--- a/lib/quality/runner.rb
+++ b/lib/quality/runner.rb
@@ -42,12 +42,14 @@ module Quality
 
     def run_quality_with_tool(tool_name, tool_exe, clazz)
       suppressed = @config.skip_tools.include? tool_name
+      return if suppressed
+
       installed = @gem_spec.find_all_by_name(tool_name).any? ||
                   !@which.which(tool_exe).nil?
 
-      if installed && !suppressed
+      if installed
         clazz.new(self).method("quality_#{tool_name}".to_sym).call
-      elsif !installed
+      else
         puts "#{tool_name} not installed"
       end
     end


### PR DESCRIPTION
If a tool is suppressed (i.e. it's in the `skip_tools` list) then I
think there shouldn't be a warning that it's not installed.

Note: Tests are currently broken, I want to first check if you agree with the change.