### PR TITLE
Allow pronto versions to float

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ env:
   - JRUBY_OPTS="--debug"
 rvm:
   # - ruby-head # excess warning logging
-  - 2.4.9
-  - 2.5.7
-  - 2.6.5
+  - 2.4
+  - 2.5
+  - 2.6
   # - 2.7.0-preview2 # See ruby-head - same issue
 #  - jruby-head # linguist gem doesn't support JRuby; bundle install doesn't work.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -295,3 +295,7 @@
 ## Changes since Quality 35.0.1
 
 * Bring pronto into base Docker image
+
+## Changes since Quality 35.1.1
+
+* Update Pronto

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM alpine:latest AS base
 
 RUN apk update && \
     apk add --no-cache ruby ruby-irb ruby-dev make gcc libc-dev git icu-dev zlib-dev g++ cmake openssl-dev coreutils && \
-    gem install --no-ri --no-rdoc bigdecimal rake etc quality bundler io-console pronto:0.9.5 'pronto-reek:<0.10.0' 'pronto-rubocop:<0.10.0' 'pronto-flay:<0.10.0' 'bundler:<2' && \
+    gem install --no-ri --no-rdoc bigdecimal rake etc quality bundler io-console pronto pronto-reek pronto-rubocop pronto-flay 'bundler:<2' && \
     gem uninstall quality && \
     strip /usr/lib/ruby/gems/2.5.0/extensions/x86_64-linux/2.5.0/rugged-*/rugged/rugged.so && \
     apk del ruby-irb ruby-dev make gcc libc-dev icu-dev zlib-dev g++ cmake openssl-dev nghttp2 curl pax-utils && \
@@ -54,7 +54,7 @@ RUN apk add --no-cache python3 py3-pip && \
     pip3 install flake8 && \
     apk del py3-pip && \
     pip3 uninstall -y pip
-RUN gem install --no-ri --no-rdoc 'pronto-flake8:<0.10.0'
+RUN gem install --no-ri --no-rdoc pronto-flake8
 
 
 FROM python-base AS python
@@ -99,7 +99,7 @@ FROM python-base as shellcheck-base
 
 COPY --from=4 /root/.cabal/bin /usr/local/bin
 RUN apk update && apk add --no-cache ruby ruby-dev # TODO: Do this as another build image
-RUN gem install --no-ri --no-rdoc 'pronto-shellcheck:<0.10.0'
+RUN gem install --no-ri --no-rdoc pronto-shellcheck
 
 
 

--- a/Rakefile
+++ b/Rakefile
@@ -93,6 +93,7 @@ task release: [:prerelease]
 #  * Note last version here:
 #       https://github.com/apiology/quality/releases
 #  * Make sure version is bumped in lib/quality/version.rb
+#  * Make a feature branch
 #  * Check in changes
 #  * Run diff like this: git log vA.B.C...
 #  * Check Changelog.md against actual checkins; add any missing content.

--- a/lib/quality/version.rb
+++ b/lib/quality/version.rb
@@ -4,5 +4,5 @@
 # reek, flog, flay and rubocop and makes sure your numbers don't get
 # any worse over time.
 module Quality
-  VERSION = '35.1.1'
+  VERSION = '35.2.0'
 end

--- a/quality.gemspec
+++ b/quality.gemspec
@@ -64,13 +64,10 @@ Gem::Specification.new do |s|
   # https://github.com/bundler/bundler/issues/3401
   s.add_development_dependency('minitest', ['~> 5'])
   s.add_development_dependency('mocha')
-  # pronto-flake8 requires pronto 0.9.5 :(
-  s.add_development_dependency('pronto', ['0.9.5'])
+  s.add_development_dependency('pronto')
   s.add_development_dependency('pronto-flake8')
-  # pronto-reek 0.10.0 requires pronto 0.10.0
-  s.add_development_dependency('pronto-reek', ['<0.10.0'])
-  # pronto-rubocop 0.10.0 requires pronto 0.10.0
-  s.add_development_dependency('pronto-rubocop', ['<0.10.0'])
+  s.add_development_dependency('pronto-reek')
+  s.add_development_dependency('pronto-rubocop')
   s.add_development_dependency('rake', ['!= 10.4.2'])
   s.add_development_dependency('simplecov')
 end

--- a/quality.gemspec
+++ b/quality.gemspec
@@ -63,7 +63,8 @@ Gem::Specification.new do |s|
   # Workaround for
   # https://github.com/bundler/bundler/issues/3401
   s.add_development_dependency('minitest', ['~> 5'])
-  s.add_development_dependency('mocha')
+  # https://github.com/apiology/quality/issues/121
+  s.add_development_dependency('mocha', ['!= 1.10.1', '!= 1.10.0'])
   s.add_development_dependency('pronto')
   s.add_development_dependency('pronto-flake8')
   s.add_development_dependency('pronto-reek')


### PR DESCRIPTION
pronto-flake8 has [lifted their restriction](https://github.com/scoremedia/pronto-flake8/commit/1fb9b1de5b77dccb73af614bd02c974cbb0ee2b7) on pronto versions - let's do the same!