### PR TITLE
Use latest mocha (v1.11.0)

### DIFF
--- a/quality.gemspec
+++ b/quality.gemspec
@@ -65,7 +65,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('minitest', ['~> 5'])
   # https://github.com/apiology/quality/issues/121
   # https://github.com/freerange/mocha/issues/436
-  s.add_development_dependency('mocha', ['<1.10'])
+  s.add_development_dependency('mocha')
   s.add_development_dependency('pronto')
   s.add_development_dependency('pronto-flake8')
   s.add_development_dependency('pronto-reek')

--- a/test/unit/test_helper.rb
+++ b/test/unit/test_helper.rb
@@ -13,7 +13,7 @@ end
 SimpleCov.refuse_coverage_drop
 require_relative '../../lib/quality/rake/task'
 require 'minitest/autorun'
-require 'mocha/setup'
+require 'mocha/minitest'
 
 def get_initializer_mocks(clazz, skip_these_keys: [])
   parameters = clazz.instance_method(:initialize).parameters

--- a/test/unit/test_task.rb
+++ b/test/unit/test_task.rb
@@ -80,7 +80,10 @@ class TestTask < BaseTestTask
     method("expect_#{tool_name}_run").call(quality_checker)
     file = self.class.sample_output(tool_name)
     lines = file.lines.map(&:strip)
-    quality_checker.expects(:execute).multiple_yields(*lines)
+    expectation = quality_checker.expects(:execute)
+    unless tool_name == 'shellcheck'
+      expectation.with_block_given.multiple_yields(*lines)
+    end
   end
 
   def expect_gemspec_tool_found(tool_name, was_found)


### PR DESCRIPTION
Since mocha v1.10.0, when an invocation matches an expectation which was instructed to yield using `Expectation#yields` or `Expectation#multiple_yields`, the stubbed method will *always* yield whether or not the invocation supplies a block.

The `quality_xxx` method on all of the `Tool` subclasses (except `Shellcheck`) invokes `Runner#ratchet_quality_cmd` with a block, but the same method on `Shellcheck` invokes it with no block. So we need to adjust the expectation accordingly.

I don't know enough about this project to know whether there's a better way to identify the `Shellcheck` `Tool` subclass within `TestTask#expect_single_tool_run`, but this solves the immediate problem when upgrading mocha.

I've also taken the liberty of fixing another unrelated mocha deprecation warning in a separate commit.

/cc @apiology 