### PR TITLE
Remove fork of pronto-flake8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,13 +56,7 @@ RUN apk add --no-cache python3 py3-pip && \
     apk del py3-pip && \
     pip3 uninstall -y pip
 
-# pronto-flake8 doesn't have an official release whose gemspec allows
-# pronto 0.10.0 as of yet, so let's install the fixed version from GitHub:
-#
-# https://github.com/scoremedia/pronto-flake8/pull/7
-#
-# RUN gem install --no-doc pronto-flake8
-RUN gem install --no-doc specific_install && gem specific_install -l https://github.com/apiology/pronto-flake8 -b relax_pronto_requirement
+RUN gem install --no-doc pronto-flake8
 
 
 

--- a/lib/quality/version.rb
+++ b/lib/quality/version.rb
@@ -4,5 +4,5 @@
 # reek, flog, flay and rubocop and makes sure your numbers don't get
 # any worse over time.
 module Quality
-  VERSION = '37.1.0'
+  VERSION = '37.1.1'
 end


### PR DESCRIPTION
With https://github.com/scoremedia/pronto-flake8/pull/8 merged and released, remove fork of pronto-flake8