### PR TITLE
Allow latest rubocop

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,11 +147,15 @@ Quality uses [semantic versioning](http://semver.org/)--any incompatible changes
 (including new tools being added) will come out as major number
 updates.
 
-This includes RuboCop upgrades - the quality gem locks in a specific
-minor version of RuboCop to avoid your metrics being bumped and
-breaking your build.
+New versions of rubocop, however, will often introduce new rules, which
+won't be universally adhered to in your code, which in turn may ratchet your
+metrics in the wrong direction!  As a result of this we recommend
+you lock your Gemfile to a specific minor version of rubocop.
 
-Expect your build to break on major upgrades if you use RuboCop.
+Expect your build to break on major upgrades of this gem,
+and minor version upgrades of rubocop.  Because this gem requires
+rubocop, rubocop will get updated when you update this gem, unless
+you have an explicit constraint on rubocop preventing it (AND YOU SHOULD!).
 
 ## Supported Ruby Versions
 

--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 97.82
+    "covered_percent": 45.63
   }
 }

--- a/lib/quality/config.rb
+++ b/lib/quality/config.rb
@@ -4,6 +4,7 @@
 # https://github.com/xsc/lein-ancient/issues/29
 # https://github.com/xsc/lein-ancient/releases
 
+require 'forwardable'
 require_relative 'linguist_source_file_globber'
 
 module Quality

--- a/quality.gemspec
+++ b/quality.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
   #
   # https://github.com/bbatsov/rubocop#installation
   s.add_runtime_dependency('mdl')
-  s.add_runtime_dependency('rubocop', '~> 0.78.0')
+  s.add_runtime_dependency('rubocop', '>= 0.78')
   # 0.2.0 had a fatal bug
   s.add_runtime_dependency('bigfiles', ['>= 0.1', '!= 0.2.0'])
   s.add_runtime_dependency('brakeman')


### PR DESCRIPTION
- [x] allow latest Rubocop
- [x] update readme to explain to users that they shoudl lock Rubocop (everyone should already be dooing this, but good to point out for new users).
- [x] Why did the coverage drop so much?  I ran `bundle exec rspec`, and has three passing examples.