### PR TITLE
Update to latest pronto, rubocop.  Retire pronto-flake8.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN apk add --no-cache python3 py3-pip && \
     pip3 install flake8 && \
     apk del py3-pip
 
-RUN gem install --no-doc pronto-flake8
+# RUN gem install --no-doc pronto-flake8  # does not yet support pronto 0.11
 
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ PATH
       rails_best_practices
       reek (>= 1.3.4)
       rest-client (>= 1.8.0)
-      rubocop (~> 0.92.0)
+      rubocop (~> 1.22.0)
       rubocop-minitest
       rubocop-rake
       rubocop-rspec (>= 1.19.0)
@@ -158,25 +158,23 @@ GEM
     parser (3.1.2.0)
       ast (~> 2.4.1)
     path_expander (1.1.1)
-    pronto (0.10.0)
-      gitlab (~> 4.0, >= 4.0.0)
+    pronto (0.11.0)
+      gitlab (~> 4.4, >= 4.4.0)
       httparty (>= 0.13.7)
       octokit (~> 4.7, >= 4.7.0)
       rainbow (>= 2.2, < 4.0)
-      rugged (~> 0.24, >= 0.23.0)
-      thor (~> 0.20.0)
+      rexml (~> 3.2)
+      rugged (>= 0.23.0, < 1.1.0)
+      thor (>= 0.20.3, < 2.0)
     pronto-bigfiles (0.1.2)
       bigfiles (>= 0.2.0)
       pronto
-    pronto-flake8 (0.4.0)
-      pronto (< 0.11.0)
-      rugged (~> 0.24, >= 0.23.0)
     pronto-punchlist (0.1.1)
       pronto
       punchlist (>= 1.3.0)
-    pronto-rubocop (0.10.0)
-      pronto (~> 0.10.0)
-      rubocop (~> 0.50, >= 0.49.1)
+    pronto-rubocop (0.11.2)
+      pronto (~> 0.11.0)
+      rubocop (>= 0.63.1, < 2.0)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -218,29 +216,28 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
-    rubocop (0.92.0)
+    rubocop (1.22.3)
       parallel (~> 1.10)
-      parser (>= 2.7.1.5)
+      parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.7)
+      regexp_parser (>= 1.8, < 3.0)
       rexml
-      rubocop-ast (>= 0.5.0)
+      rubocop-ast (>= 1.12.0, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 2.0)
+      unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.18.0)
       parser (>= 3.1.1.0)
     rubocop-minitest (0.20.1)
       rubocop (>= 0.90, < 2.0)
     rubocop-rake (0.5.1)
       rubocop
-    rubocop-rspec (1.44.1)
-      rubocop (~> 0.87)
-      rubocop-ast (>= 0.7.1)
+    rubocop-rspec (2.11.1)
+      rubocop (~> 1.19)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
     ruby_parser (3.19.1)
       sexp_processor (~> 4.16)
-    rugged (0.99.0)
+    rugged (1.0.1)
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
@@ -258,7 +255,7 @@ GEM
       tins (~> 1.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
-    thor (0.20.3)
+    thor (1.2.1)
     tins (1.31.1)
       sync
     tomlrb (2.0.3)
@@ -271,7 +268,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
-    unicode-display_width (1.8.0)
+    unicode-display_width (2.2.0)
     zeitwerk (2.6.0)
 
 PLATFORMS
@@ -287,9 +284,8 @@ DEPENDENCIES
   minitest (~> 5)
   mocha
   overcommit (>= 0.58.0)
-  pronto
+  pronto (>= 0.11)
   pronto-bigfiles
-  pronto-flake8
   pronto-punchlist
   pronto-rubocop
   pry

--- a/quality.gemspec
+++ b/quality.gemspec
@@ -38,9 +38,9 @@ Gem::Specification.new do |spec|
   # magit doesn't seem to want to use the bundled version at the moment,
   # so let's favor the more recent version...
   spec.add_development_dependency 'overcommit', ['>=0.58.0']
-  spec.add_development_dependency('pronto')
+  spec.add_development_dependency('pronto', '>=0.11')
   spec.add_development_dependency('pronto-bigfiles')
-  spec.add_development_dependency('pronto-flake8')
+  # spec.add_development_dependency('pronto-flake8') # does not yet support pronto 0.11
   spec.add_development_dependency('pronto-punchlist')
   spec.add_development_dependency('pronto-rubocop')
   spec.add_development_dependency 'pry'
@@ -67,7 +67,7 @@ Gem::Specification.new do |spec|
   #
   # https://github.com/bbatsov/rubocop#installation
   spec.add_runtime_dependency('mdl')
-  spec.add_runtime_dependency('rubocop', '~> 0.92.0')
+  spec.add_runtime_dependency('rubocop', '~> 1.22.0')
   # 0.2.0 had a fatal bug
   # 0.3.0 introduces config files
   spec.add_runtime_dependency('bigfiles', ['>= 0.3.0', '!= 0.2.0'])


### PR DESCRIPTION
pronto-flake8 was holding back rubocop from being upgraded, as pronto-flake8 does not support the latest pronto.